### PR TITLE
Fix for minifying empty style tags.

### DIFF
--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -49,7 +49,7 @@ exports.minifyCss = function (css) {
      *
      */
     // For each : within a css selector, remove surrounding white space.
-    var selectors = minCss.match(/.*?\{([^{}]*?\{.*?\}|.*?);?\}/g);
+    var selectors = minCss.match(/.*?\{([^{}]*?\{.*?\}|.*?);?\}/g) || [];
 
     for (var i = 0; i < selectors.length; i++) {
         var rules = selectors[i].match(/\{([^{}]*?\{.*?\}|.*?);?\}/g);

--- a/test/expected/inline_css/empty-style-tag.html
+++ b/test/expected/inline_css/empty-style-tag.html
@@ -1,0 +1,1 @@
+<style></style>

--- a/test/fixtures/inline_css/empty-style-tag.html
+++ b/test/fixtures/inline_css/empty-style-tag.html
@@ -1,0 +1,2 @@
+<style>
+</style>


### PR DESCRIPTION
The util.minifyCss method appears to fail when the regular expression for CSS selectors doesn't find any matches. The string.match method returns null in this case which leads to an attempt to read a property off a null value. This fix simply ensures that the selectors array cannot be null.
